### PR TITLE
Add context to serializers in Panko::Response

### DIFF
--- a/lib/panko/response.rb
+++ b/lib/panko/response.rb
@@ -22,12 +22,13 @@ module Panko
       Panko::JsonValue.from(value)
     end
 
-    def self.array_serializer(data, serializer)
-      Panko::ArraySerializer.new(data, each_serializer: serializer)
+    def self.array_serializer(data, serializer, options = {})
+      merged_options = options.merge(each_serializer: serializer)
+      Panko::ArraySerializer.new(data, merged_options)
     end
 
-    def self.serializer(data, serializer)
-      json serializer.new.serialize_to_json(data)
+    def self.serializer(data, serializer, options = {})
+      json serializer.new(options).serialize_to_json(data)
     end
   end
 


### PR DESCRIPTION
A small addition to allow for usage of context in Panko::Response.
Example

```ruby
context = { value: "something" }
response = Panko::Response.create do |t|
  [
    {
      data: t.value(
        foos: t.array_serializer(Foo.all, FooWithContextSerializer, context: context),
        foo: t.serializer(Foo.first, FooWithContextSerializer, context: context)
      )
    }
  ]
end
```
Specially useful when using Panko::Response for single object serialization.