### PR TITLE
Register global variables to the GC

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,8 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7']
-        rails: ['5.2.0', '6.0.0', '6.1.0rc1']
+        ruby: [ '2.5', '2.6', '2.7', '3.0']
+        rails: ['5.2.0', '6.0.0', '6.1.0']
+        exclude:
+          - ruby: '3.0'
+            rails: '5.2.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/ext/panko_serializer/attributes_writer/attributes_writer.c
+++ b/ext/panko_serializer/attributes_writer/attributes_writer.c
@@ -2,7 +2,6 @@
 
 static bool types_initialized = false;
 static VALUE ar_base_type = Qundef;
-static VALUE hash_type = Qundef;
 
 VALUE init_types(VALUE v) {
   if (types_initialized == true) {
@@ -15,8 +14,7 @@ VALUE init_types(VALUE v) {
       rb_const_get_at(rb_cObject, rb_intern("ActiveRecord"));
 
   ar_base_type = rb_const_get_at(ar_type, rb_intern("Base"));
-
-  hash_type = rb_const_get_at(rb_cObject, rb_intern("Hash"));
+  rb_global_variable(&ar_base_type);
 
   return Qundef;
 }
@@ -35,7 +33,7 @@ AttributesWriter create_attributes_writer(VALUE object) {
           .write_attributes = active_record_attributes_writer};
   }
 
-  if (rb_obj_is_kind_of(object, hash_type) == Qtrue) {
+  if (!RB_SPECIAL_CONST_P(object) && BUILTIN_TYPE(object) == T_HASH) {
     return (AttributesWriter){.object_type = Hash,
                             .write_attributes = hash_attributes_writer};
   }

--- a/ext/panko_serializer/attributes_writer/type_cast/type_cast.c
+++ b/ext/panko_serializer/attributes_writer/type_cast/type_cast.c
@@ -362,4 +362,20 @@ void panko_init_type_cast(VALUE mPanko) {
   rb_define_singleton_method(mPanko, "_type_cast", public_type_cast, -1);
 
   panko_init_time(mPanko);
+
+  rb_global_variable(&oj_type);
+  rb_global_variable(&oj_parseerror_type);
+  rb_global_variable(&ar_string_type);
+  rb_global_variable(&ar_text_type);
+  rb_global_variable(&ar_float_type);
+  rb_global_variable(&ar_integer_type);
+  rb_global_variable(&ar_boolean_type);
+  rb_global_variable(&ar_date_time_type);
+  rb_global_variable(&ar_time_zone_converter);
+  rb_global_variable(&ar_json_type);
+  rb_global_variable(&ar_pg_integer_type);
+  rb_global_variable(&ar_pg_float_type);
+  rb_global_variable(&ar_pg_uuid_type);
+  rb_global_variable(&ar_pg_json_type);
+  rb_global_variable(&ar_pg_date_time_type);
 }

--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -77,6 +77,7 @@ VALUE association_decriptor_aset(VALUE self, VALUE descriptor) {
 
 void panko_init_association(VALUE mPanko) {
   cAssociation = rb_define_class_under(mPanko, "Association", rb_cObject);
+  rb_global_variable(&cAssociation);
 
   rb_define_module_function(cAssociation, "new", association_new, -1);
 

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -85,6 +85,7 @@ void panko_init_attribute(VALUE mPanko) {
   attribute_aliases_id = rb_intern("attribute_aliases");
 
   cAttribute = rb_define_class_under(mPanko, "Attribute", rb_cObject);
+  rb_global_variable(&cAttribute);
 
   rb_define_module_function(cAttribute, "new", attribute_new, -1);
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,3 +61,9 @@ RSpec::Matchers.define :serialized_as do |serializer_factory_or_class, output|
     FAILURE
   end
 end
+
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end


### PR DESCRIPTION
### Context

Ruby 2.7 introduced GC compaction. This means that objects can me moved from on GC slot to another. Since then C extensions must declare all the `VALUE` they keep in global variables with `rb_global_variable`. This allow the GC to update the references held by C extensions.

Ruby 3.0 added `GC.verify_compaction_references` which makes it easier to test that all references are properly declared. All objects are moved to new heap pages, so after than any attempt to use undeclared global variable is extremly likely to segfault.

### This PR

I simply declare all the global variables and add Ruby 3.0 to the test matrix.