### PR TITLE
Allow to dynamically skip a field by returning SKIP

### DIFF
--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -32,6 +32,8 @@ end
 
 module Panko
   class Serializer
+    SKIP = Object.new.freeze
+
     class << self
       def inherited(base)
         if _descriptor.nil?

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -177,6 +177,20 @@ describe Panko::Serializer do
       expect(Foo.create).to serialized_as(FooSerializer, "name" => nil, "address" => nil)
     end
 
+    it "can skip fields" do
+      class FooSkipSerializer < FooSerializer
+        def address
+          object.address || SKIP
+        end
+      end
+
+      foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      expect(foo).to serialized_as(FooSkipSerializer, "name" => foo.name, "address" => foo.address)
+
+      foo = Foo.create(name: Faker::Lorem.word, address: nil).reload
+      expect(foo).to serialized_as(FooSkipSerializer, "name" => foo.name)
+    end
+
     it "preserves changed attributes" do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 


### PR DESCRIPTION
### Context

I'm trying to convert one of our app that uses AMS 0.9 (https://github.com/Shopify/shipit-engine/pull/1139), but one missing feature the the possibility of skipping an attribute.

I've read https://github.com/panko-serializer/panko_serializer/issues/16 and I understand the performance concern, however I think it can be done efficiently.

### This PR

It define a special value `Panko::Serializer::SKIP`, if a serializer field returns it, the field is not serialized. The performance overhead should be totally negligible.