### PR TITLE
Respect namespacing in SerializerResolver

### DIFF
--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -75,7 +75,7 @@ module Panko
 
       def has_one(name, options = {})
         serializer_const = options[:serializer]
-        serializer_const = Panko::SerializerResolver.resolve(name.to_s) if serializer_const.nil?
+        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil?
 
         raise "Can't find serializer for #{self.name}.#{name} has_one relationship." if serializer_const.nil?
 
@@ -88,7 +88,7 @@ module Panko
 
       def has_many(name, options = {})
         serializer_const = options[:serializer] || options[:each_serializer]
-        serializer_const = Panko::SerializerResolver.resolve(name.to_s) if serializer_const.nil?
+        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil?
 
         raise "Can't find serializer for #{self.name}.#{name} has_many relationship." if serializer_const.nil?
 

--- a/panko_serializer.gemspec
+++ b/panko_serializer.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.extensions << "ext/panko_serializer/extconf.rb"
 
   spec.add_dependency "oj", "~> 3.10.0"
+  spec.add_dependency "activesupport"
 end

--- a/spec/panko/serializer_resolver_spec.rb
+++ b/spec/panko/serializer_resolver_spec.rb
@@ -7,7 +7,7 @@ describe Panko::SerializerResolver do
     class CoolSerializer < Panko::Serializer
     end
 
-    result = Panko::SerializerResolver.resolve("cool")
+    result = Panko::SerializerResolver.resolve("cool", Object)
 
     expect(result._descriptor).to be_a(Panko::SerializationDescriptor)
     expect(result._descriptor.type).to eq(CoolSerializer)
@@ -17,7 +17,7 @@ describe Panko::SerializerResolver do
     class PersonSerializer < Panko::Serializer
     end
 
-    result = Panko::SerializerResolver.resolve("persons")
+    result = Panko::SerializerResolver.resolve("persons", Object)
 
     expect(result._descriptor).to be_a(Panko::SerializationDescriptor)
     expect(result._descriptor.type).to eq(PersonSerializer)
@@ -27,22 +27,42 @@ describe Panko::SerializerResolver do
     class MyCoolSerializer < Panko::Serializer
     end
 
-    result = Panko::SerializerResolver.resolve("my_cool")
+    result = Panko::SerializerResolver.resolve("my_cool", Object)
 
     expect(result._descriptor).to be_a(Panko::SerializationDescriptor)
     expect(result._descriptor.type).to eq(MyCoolSerializer)
   end
 
+  it "resolves serializer in namespace first" do
+    class CoolSerializer < Panko::Serializer
+    end
+    module MyApp
+      class CoolSerializer < Panko::Serializer
+      end
+
+      class PersonSerializer < Panko::Serializer
+      end
+    end
+
+    result = Panko::SerializerResolver.resolve("cool", MyApp::PersonSerializer)
+    expect(result._descriptor).to be_a(Panko::SerializationDescriptor)
+    expect(result._descriptor.type).to eq(MyApp::CoolSerializer)
+
+    result = Panko::SerializerResolver.resolve("cool", Panko)
+    expect(result._descriptor).to be_a(Panko::SerializationDescriptor)
+    expect(result._descriptor.type).to eq(CoolSerializer)
+  end
+
   describe "errors cases" do
     it "returns nil when the serializer name can't be found" do
-      expect(Panko::SerializerResolver.resolve("post")).to be_nil
+      expect(Panko::SerializerResolver.resolve("post", Object)).to be_nil
     end
 
     it "returns nil when the serializer is not Panko::Serializer" do
       class SomeObjectSerializer
       end
 
-      expect(Panko::SerializerResolver.resolve("some_object")).to be_nil
+      expect(Panko::SerializerResolver.resolve("some_object", Object)).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Context

I'm trying to convert one of our app that uses AMS 0.9 (Shopify/shipit-engine#1139), and one small issue I ran into is that Shipit is a Rails engine, as such all constants are namespaced under `Shipit::`.

So none of the automatic serializer resolution worked because it would look for e.g. `::UserSerializer` instead of `Shipit::UserSerializer`.


### This PR

We simply first look for a serializer inside the namespace we're defining the relation, if not found we fallback to the top level namespace.

PS: thanks for the two very quick merges!