### PR TITLE
Add support for passing serializer as string in has_many association

### DIFF
--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -88,7 +88,7 @@ module Panko
 
       def has_many(name, options = {})
         serializer_const = options[:serializer] || options[:each_serializer]
-        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil?
+        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil? || serializer_const.kind_of?(String)
 
         raise "Can't find serializer for #{self.name}.#{name} has_many relationship." if serializer_const.nil?
 

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -456,6 +456,30 @@ describe Panko::Serializer do
                                                        ])
     end
 
+    it "accepts serializer name as string" do
+      class FoosHasManyHolderSerializer < Panko::Serializer
+        attributes :name
+
+        has_many :foos, serializer: "FooSerializer"
+      end
+
+      foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
+
+      expect(foos_holder).to serialized_as(FoosHasManyHolderSerializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "name" => foo1.name,
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "name" => foo2.name,
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
+    end
+
     it "supports :name" do
       class FoosHasManyHolderWithNameSerializer < Panko::Serializer
         attributes :name


### PR DESCRIPTION
This is a follow up to #108, and adds support for passing in `serializer` as a string in the `has_many` association.