### PR TITLE
Allow more flexibility in how serializers are resolved when strings are passed to the serializer option

### DIFF
--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -75,7 +75,10 @@ module Panko
 
       def has_one(name, options = {})
         serializer_const = options[:serializer]
-        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil? || serializer_const.kind_of?(String)
+        if serializer_const.kind_of?(String)
+          serializer_const = Panko::SerializerResolver.resolve(serializer_const, self)
+        end
+        serializer_const ||= Panko::SerializerResolver.resolve(name.to_s, self)
 
         raise "Can't find serializer for #{self.name}.#{name} has_one relationship." if serializer_const.nil?
 
@@ -88,7 +91,10 @@ module Panko
 
       def has_many(name, options = {})
         serializer_const = options[:serializer] || options[:each_serializer]
-        serializer_const = Panko::SerializerResolver.resolve(name.to_s, self) if serializer_const.nil? || serializer_const.kind_of?(String)
+        if serializer_const.kind_of?(String)
+          serializer_const = Panko::SerializerResolver.resolve(serializer_const, self)
+        end
+        serializer_const ||= Panko::SerializerResolver.resolve(name.to_s, self)
 
         raise "Can't find serializer for #{self.name}.#{name} has_many relationship." if serializer_const.nil?
 

--- a/lib/panko/serializer_resolver.rb
+++ b/lib/panko/serializer_resolver.rb
@@ -13,6 +13,7 @@ class Panko::SerializerResolver
       end
 
       serializer_const ||= safe_serializer_get("#{name.singularize.camelize}Serializer")
+      serializer_const ||= safe_serializer_get(name)
       serializer_const
     end
 

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -23,6 +23,16 @@ ActiveRecord::Schema.define do
     t.timestamps(null: false)
   end
 
+  create_table :goos, force: true do |t|
+    t.string :name
+    t.string :address
+
+    t.references :foos_holder
+    t.references :foo_holder
+
+    t.timestamps(null: false)
+  end
+
   create_table :foo_holders, force: true do |t|
     t.string :name
     t.references :foo
@@ -40,10 +50,15 @@ end
 class Foo < ActiveRecord::Base
 end
 
+class Goo < ActiveRecord::Base
+end
+
 class FoosHolder < ActiveRecord::Base
   has_many :foos
+  has_many :goos
 end
 
 class FooHolder < ActiveRecord::Base
   has_one :foo
+  has_one :goo
 end

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -333,6 +333,26 @@ describe Panko::Serializer do
                                                       })
     end
 
+    it "can use the serializer string name when resolving the serializer" do
+      class FooHolderHasOnePooWithStringSerializer < Panko::Serializer
+        attributes :name
+
+        has_one :goo, serializer: "FooSerializer"
+      end
+
+      goo = Goo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      foo_holder = FooHolder.create(name: Faker::Lorem.word, goo: goo).reload
+
+      expect(foo_holder).to serialized_as(
+        FooHolderHasOnePooWithStringSerializer,
+        "name" => foo_holder.name,
+        "goo" => {
+          "name" => goo.name,
+          "address" => goo.address
+        }
+      )
+    end
+
     it "accepts name option" do
       class FooHolderHasOneWithNameSerializer < Panko::Serializer
         attributes :name
@@ -478,6 +498,33 @@ describe Panko::Serializer do
                                                            "address" => foo2.address
                                                          }
                                                        ])
+    end
+
+    it "uses the serializer string name when resolving the serializer" do
+      class FoosHasManyPoosHolderSerializer < Panko::Serializer
+        attributes :name
+
+        has_many :goos, serializer: "FooSerializer"
+      end
+
+      goo1 = Goo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      goo2 = Goo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      foos_holder = FoosHolder.create(name: Faker::Lorem.word, goos: [goo1, goo2]).reload
+
+      expect(foos_holder).to serialized_as(
+        FoosHasManyPoosHolderSerializer,
+        "name" => foos_holder.name,
+        "goos" => [
+          {
+            "name" => goo1.name,
+            "address" => goo1.address
+          },
+          {
+            "name" => goo2.name,
+            "address" => goo2.address
+          }
+        ]
+      )
     end
 
     it "supports :name" do


### PR DESCRIPTION
This PR allows has_one and has_many associations to use a different serializer than the association name, if a string is passed in for the serializer.

Using a real world example - If you have this defined: `has_one :current_driver, serializer: "User"` in a Vehicle, the serializer resolver will always look for `CurrentDriverSerializer`, which is not the correct serializer, because we wanted a `UserSerializer`.