### PR TITLE
Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1.0"]
+        ruby: ["2.7", "3.0", "3.1.0", "3.2.0"]
         rails: ["6.0.0", "6.1.0", "7.0.0"]
 
     steps:

--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -77,6 +77,7 @@ VALUE association_decriptor_aset(VALUE self, VALUE descriptor) {
 
 void panko_init_association(VALUE mPanko) {
   cAssociation = rb_define_class_under(mPanko, "Association", rb_cObject);
+  rb_undef_alloc_func(cAssociation);
   rb_global_variable(&cAssociation);
 
   rb_define_module_function(cAssociation, "new", association_new, -1);

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -85,6 +85,7 @@ void panko_init_attribute(VALUE mPanko) {
   attribute_aliases_id = rb_intern("attribute_aliases");
 
   cAttribute = rb_define_class_under(mPanko, "Attribute", rb_cObject);
+  rb_undef_alloc_func(cAttribute);
   rb_global_variable(&cAttribute);
 
   rb_define_module_function(cAttribute, "new", attribute_new, -1);


### PR DESCRIPTION
Update test matrix to run for 3.2.0 and remove [some warnings](https://bugs.ruby-lang.org/issues/18007) 