### PR TITLE
Fix memory leak which caused by exception

### DIFF
--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -31,11 +31,12 @@ void association_mark(Association data) {
 }
 
 static VALUE association_new(int argc, VALUE* argv, VALUE self) {
-  Association association = ALLOC(struct _Association);
+  Association association;
 
   Check_Type(argv[0], T_SYMBOL);
   Check_Type(argv[1], T_STRING);
 
+  association = ALLOC(struct _Association);
   association->name_sym = argv[0];
   association->name_str = argv[1];
   association->rb_descriptor = argv[2];

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -26,13 +26,14 @@ void attribute_mark(Attribute data) {
 }
 
 static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
-  Attribute attribute = ALLOC(struct _Attribute);
+  Attribute attribute;
 
   Check_Type(argv[0], T_STRING);
   if (argv[1] != Qnil) {
     Check_Type(argv[1], T_STRING);
   }
 
+  attribute = ALLOC(struct _Attribute);
   attribute->name_str = argv[0];
   attribute->name_id = rb_intern_str(attribute->name_str);
   attribute->alias_name = argv[1];


### PR DESCRIPTION
When it invoked Data_Wrap_Struct(), Ruby's GC can release allocated memory properly. However, we have to manage the memory ourselves until invoking Data_Wrap_Struct().

Check_Type() will raise an exception if the argument is not a string, and memory leak will be caused by the exception.

So, I think ALLOC() should be called after Check_Type().

You will see an increase memory usage with attached test code.

### Before
```
0, 19.3828125 MB
5000, 20.19140625 MB
10000, 20.70703125 MB
15000, 21.22265625 MB
20000, 21.73828125 MB
25000, 22.25390625 MB
30000, 22.76953125 MB
```

### After
```
0, 19.359375 MB
5000, 19.90234375 MB
10000, 19.90234375 MB
15000, 19.90234375 MB
20000, 19.90234375 MB
25000, 19.90234375 MB
30000, 19.90234375 MB
```

### Test code
```ruby
require 'panko_serializer'

30_001.times do |i|
  Panko::Association.new(123, 456, 789) rescue nil
  Panko::Attribute.new(123456789) rescue nil

  rss = Integer(`ps -o rss= -p #{Process.pid}`) / 1024.0
  puts "#{i}, #{rss} MB" if i % 5000 == 0
end
```