### PR TITLE
Keep alias_name when method_added (#135)

### DIFF
--- a/ext/panko_serializer/panko_serializer.c
+++ b/ext/panko_serializer/panko_serializer.c
@@ -29,7 +29,7 @@ void serialize_method_fields(VALUE object, VALUE str_writer,
     return;
   }
 
-  volatile VALUE method_fields, serializer;
+  volatile VALUE method_fields, serializer, key;
   long i;
 
   method_fields = descriptor->method_fields;
@@ -43,7 +43,8 @@ void serialize_method_fields(VALUE object, VALUE str_writer,
 
     volatile VALUE result = rb_funcall(serializer, attribute->name_id, 0);
     if (result != SKIP) {
-      write_value(str_writer, attribute->name_str, result, Qfalse);
+      key = attr_name_for_serialization(attribute);
+      write_value(str_writer, key, result, Qfalse);
     }
   }
 

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -70,7 +70,7 @@ module Panko
         return if @_descriptor.nil?
 
         deleted_attr = @_descriptor.attributes.delete(method)
-        @_descriptor.method_fields << Attribute.create(method) unless deleted_attr.nil?
+        @_descriptor.method_fields << Attribute.create(deleted_attr.name, alias_name: deleted_attr.alias_name) unless deleted_attr.nil?
       end
 
       def has_one(name, options = {})

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -706,4 +706,39 @@ describe Panko::Serializer do
       expect { serializer.serialize(foo_b) }.to raise_error(ArgumentError, "Panko::Serializer instances are single-use")
     end
   end
+
+  context "alias" do
+    let(:data) { {"created_at" => created_at} }
+    let(:created_at) { "2023-04-18T09:24:41+00:00" }
+
+    context "with alias" do
+      let(:serializer_class) do
+        Class.new(Panko::Serializer) do
+          aliases({created_at: :createdAt})
+        end
+      end
+
+      it "has createdAt" do
+        expect(data).to serialized_as(serializer_class,
+          "createdAt" => created_at)
+      end
+    end
+
+    context "with alias + method_fields" do
+      let(:serializer_class) do
+        Class.new(Panko::Serializer) do
+          aliases({created_at: :createdAt})
+
+          def created_at
+            "2023-04-18T09:24:41+00:00"
+          end
+        end
+      end
+
+      it "has createdAt" do
+        expect(data).to serialized_as(serializer_class,
+          "createdAt" => created_at)
+      end
+    end
+  end
 end


### PR DESCRIPTION
`method_added` removes the same name attribute from `attributes` and add a new one to `method_fields`. It ignores `alias_name` of the original attribute.
Then the alias setting does not work with method fields.

With this patch, the original `alias_name` is kept.

In addition, `serialize_method_fields` does not use `attr_name_for_serialization` unlike other serialize functions. This patch also fixes it to use the function.